### PR TITLE
🥅 Fail with Fatal instead of Panic when gitmojis file is corrupted

### DIFF
--- a/tmpl/template.go
+++ b/tmpl/template.go
@@ -263,7 +263,7 @@ func promptGitmoji() (gitmoji.Gitmoji, error) {
 	glist, err := cache.GetGitmoji()
 
 	if err != nil {
-		log.Panic("Unable to get list of gitmoji: ", err)
+		log.Fatal("Unable to get list of gitmoji: ", err)
 	}
 
 	templates := &promptui.SelectTemplates{


### PR DESCRIPTION
# Problem

When I first began using `gogitmoji`, it came across the following issue on my first run of the binary, without any argument:

```
Using config file: /home/horgix/.gitmoji/config.yaml
2020/11/11 14:03:02 Unable to get list of gitmoji: Cannot process gitmoji list; perhaps the file is corrupted? Underlying error: [...]
panic: Unable to get list of gitmoji: Cannot process gitmoji list; perhaps the file is corrupted? Underlying error: [...]

goroutine 1 [running]:
log.Panic(0xc000157868, 0x2, 0x2)
	/home/travis/.gimme/versions/go1.14.linux.amd64/src/log/log.go:351 +0xac
github.com/jamesdobson/gogitmoji/tmpl.promptGitmoji(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/jamesdobson/gogitmoji/tmpl/template.go:266 +0x187
github.com/jamesdobson/gogitmoji/tmpl.getAnswers(0xc00000a1e0, 0x5, 0x5, 0xc000028e90, 0x3, 0xc000186150, 0x3, 0x3, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/jamesdobson/gogitmoji/tmpl/template.go:110 +0x344
github.com/jamesdobson/gogitmoji/tmpl.RunTemplateCommand(0xc00000a1e0, 0x5, 0x5, 0xc000028e90, 0x3, 0xc000186150, 0x3, 0x3, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/jamesdobson/gogitmoji/tmpl/template.go:68 +0x60
github.com/jamesdobson/gogitmoji/cmd.commit()
	/home/travis/gopath/src/github.com/jamesdobson/gogitmoji/cmd/commit.go:84 +0x1ab
github.com/jamesdobson/gogitmoji/cmd.glob..func5(0xd292c0, 0xd5cba8, 0x0, 0x0)
	/home/travis/gopath/src/github.com/jamesdobson/gogitmoji/cmd/root.go:21 +0x20
github.com/spf13/cobra.(*Command).execute(0xd292c0, 0xc00001e1d0, 0x0, 0x0, 0xd292c0, 0xc00001e1d0)
	/home/travis/gopath/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0xd292c0, 0x937a20, 0x7, 0x1)
	/home/travis/gopath/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/home/travis/gopath/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/jamesdobson/gogitmoji/cmd.Execute()
	/home/travis/gopath/src/github.com/jamesdobson/gogitmoji/cmd/root.go:33 +0x31
main.main()
	/home/travis/gopath/src/github.com/jamesdobson/gogitmoji/main.go:28 +0xbc
```

The problem was that I already had a file `gitmojis.json` from the "original" `gitmoji` command in JS.

I really believed that something was fundamentally broken when I saw a panic/stacktrace, and almost gave up instantly. The error is hidden on top of the stacktrace. I easily solved it by regenerating the `gitmojis.json` with `gogitmoji`, but I believe this could be friendlier to new users.

# Proposal

This PR simply fails with `Fatal` instead of `Panic`. The result is friendlier for the user, and carry the same bit of information, just not in the middle of a stacktrace:

```
Using config file: /home/horgix/.gitmoji/config.yaml
2020/11/11 14:03:02 Unable to get list of gitmoji: Cannot process gitmoji list; perhaps the file is corrupted? Underlying error: [...]\
```