### PR TITLE
✨ Add cache file path to error message

### DIFF
--- a/gitmoji/cache.go
+++ b/gitmoji/cache.go
@@ -182,7 +182,7 @@ func (cache *Cache) GetGitmoji() ([]Gitmoji, error) {
 	err = json.Unmarshal(content, &container)
 
 	if err != nil {
-		return nil, fmt.Errorf("Cannot process gitmoji list; perhaps the file is corrupted? Underlying error: %v", err)
+		return nil, fmt.Errorf("Cannot process gitmoji list; perhaps the file %v is corrupted? Underlying error: %v", cache.CacheFile, err)
 	}
 
 	cache.gitmoji = container.Gitmoji


### PR DESCRIPTION
# Issue

When failing to load the `gitmojis.json` file, the message is kinda generic and mention `the file` without any more details.

# Proposal

This PR simply adds the filename to the failure message so it's easier for users to find it and fix it.