### PR TITLE
✨ Allow to start in search mode (Closes #36)

### DIFF
--- a/tmpl/template.go
+++ b/tmpl/template.go
@@ -26,12 +26,13 @@ type CommandTemplate struct {
 
 // Prompt defines a question to ask the user.
 type Prompt struct {
-	Type      string         `yaml:"Type"`
-	Mandatory bool           `yaml:"Mandatory,omitempty"`
-	Prompt    string         `yaml:"Prompt,omitempty"`
-	Name      string         `yaml:"Name"`
-	Condition string         `yaml:"Condition,omitempty"`
-	Choices   []PromptChoice `yaml:"Choices,omitempty"`
+	Type      string          `yaml:"Type"`
+	Mandatory bool            `yaml:"Mandatory,omitempty"`
+	Prompt    string          `yaml:"Prompt,omitempty"`
+	Name      string          `yaml:"Name"`
+	Condition string          `yaml:"Condition,omitempty"`
+	Choices   []PromptChoice  `yaml:"Choices,omitempty"`
+	Config    map[string]bool `yaml:"Config,omitempty"`
 }
 
 // PromptChoice defines a single option in a multiple-choice prompt.
@@ -107,7 +108,11 @@ func getAnswers(tpl CommandTemplate) map[string]interface{} {
 			answers[question.Name] = answer
 
 		case "gitmoji":
-			gitmoji, err := promptGitmoji()
+			search, ok := question.Config["StartInSearchMode"]
+			if !ok {
+				search = false
+			}
+			gitmoji, err := promptGitmoji(search)
 
 			if err != nil {
 				if err == promptui.ErrInterrupt {
@@ -253,7 +258,7 @@ func prompt(question string, mandatory bool) (string, error) {
 	return result, nil
 }
 
-func promptGitmoji() (gitmoji.Gitmoji, error) {
+func promptGitmoji(startInSearchMode bool) (gitmoji.Gitmoji, error) {
 	cache, err := gitmoji.NewCache()
 
 	if err != nil {
@@ -291,11 +296,12 @@ func promptGitmoji() (gitmoji.Gitmoji, error) {
 	}
 
 	prompt := promptui.Select{
-		Label:     "Choose a gitmoji",
-		Items:     glist,
-		Templates: templates,
-		Size:      12,
-		Searcher:  searcher,
+		Label:             "Choose a gitmoji",
+		Items:             glist,
+		Templates:         templates,
+		Size:              12,
+		Searcher:          searcher,
+		StartInSearchMode: startInSearchMode,
 	}
 
 	i, _, err := prompt.Run()


### PR DESCRIPTION
This is a really naive and bare bones implementation of #36, which allow starting in search mode for emoji choice by configuring it in the template file like so:

```yaml
Prompts:
    - Type: gitmoji
      Mandatory: true
      Name: gitmoji
      Config:
        StartInSearchMode: true
```

This is only a draft for now, I'm looking for feedback on the approach. I tried to make it configurable though top-level configuration keys in the file as well as through the CLI flags but for now the templating part is completely split from the rest of the processing so it was kind of a hassle to do it like that. I instead went with the Prompt configuration, and the `Config` map could open to other usecases imho.

If this feature and this approach was to be approved in theory, I would add relevant examples/docs to the README as well as maybe some comments on how it works / some more checks to ensure nothing goes wrong with such a `Config` map :slightly_smiling_face: 